### PR TITLE
Allow specifying a custom `cache-dependency-path`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ It is designed to perform some basic setup and install some tools that are commo
 
 ## Usage
 
+See [action.yml](action.yml) for full details.
+
+### Example
 
 ```
 ...
@@ -17,6 +20,7 @@ jobs:
     steps:
       - uses: "opensafely-core/setup-action@v1"
         with:
-          python-version: 3.10
+          python-version: "3.10"
+          cache-dependency-path: "requirements.*.txt"
           install-just: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: 'Setup Action'
 description: 'Setup an OpenSAFELY environment'
 
 inputs:
+  cache-dependency-path:
+    description: 'The path to dependency files whose dependencies should be cached.'
+    required: false
+    default: 'requirements.*.txt'
   python-version:
     description: 'The Python version to use. A value is required in order to install Python'
     required: false
@@ -21,7 +25,7 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache: "pip"
-        cache-dependency-path: requirements.*.txt
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
     - name: Install just
       if: ${{ inputs.install-just }}
       shell: bash


### PR DESCRIPTION
This was hardcoded to the usual Python requirements path.

It would be useful to replace the `extractions/just` action in this [documentation workflow](https://github.com/opensafely/documentation/blob/5f2454b4dc93022920c739eea54637816862a630/.github/workflows/check_snippets.yml), as in opensafely/documentation#1087
but the requirements to cache there are actually in a subdirectory.