### PR TITLE
Correct the `install-just.sh` path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ runs:
       shell: bash
       run: |
         mkdir -p "$HOME/bin"
-        bash install-just.sh --to "$HOME/bin" --tag 1.11.0
+        bash "${{ github.action_path }}"/install-just.sh --to "$HOME/bin" --tag 1.11.0
         echo "$HOME/bin" >> $GITHUB_PATH


### PR DESCRIPTION
This worked in the tests here, because the path was that of this action itself.

For other actions using this composite action, the file being referred to would not be in the path, and so the action fails.