### PR TITLE
Remove `actions/checkout`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,6 @@ runs:
   using: 'composite'
 
   steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - uses: "actions/setup-python@v4"
       if: ${{ inputs.python-version }}
       with:


### PR DESCRIPTION
There was discussion about this previously which resulted in the `checkout` action being added to all consumers of this action.

This possibly warrants a version bump to v2, because it is a breaking change, although that will mean updating the action version everywhere.