### PR TITLE
Switch `windows-2019` for `windows-2025`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,8 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-24.04
-          - windows-2019
           - windows-2022
+          - windows-2025
           - macOS-14
           - macOS-13
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The `windows-2019` GitHub Actions runner image is deprecated, and will be removed by 2025-06-30.

https://github.blog/changelog/2025-04-15-upcoming-breaking-changes-and-releases-for-github-actions/#windows-server-2019-is-closing-down