### PR TITLE
Make dependency caching optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: 'Setup Action'
 description: 'Setup an OpenSAFELY environment'
 
 inputs:
+  cache:
+    description: 'If dependencies should be cached, use this parameter to specify the package manager. Supported values: pip, pipenv, poetry. Set to null to disable dependency caching'
+    required: false
+    default: 'pip'
   cache-dependency-path:
     description: 'The path to dependency files whose dependencies should be cached.'
     required: false
@@ -21,7 +25,7 @@ runs:
       if: ${{ inputs.python-version }}
       with:
         python-version: ${{ inputs.python-version }}
-        cache: "pip"
+        cache: ${{ inputs.cache }}
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
     - name: Install just
       if: ${{ inputs.install-just }}


### PR DESCRIPTION
Allow this action to be used with uv projects, which do not have a pip cache.

Keep pip as the default dependency cache, so that we don't have to migrate all the existing pip projects. This is likely to change in future when more projects use uv.

See [Slack discussion](https://bennettoxford.slack.com/archives/C63UXGB8E/p1754566938703689?thread_ts=1754542844.756329&cid=C63UXGB8E) and [this example usage PR](https://github.com/opensafely-core/tpp-database-utils/pull/15). Making this parameter optional means we no longer need to pin uv repos to a commit which has not been merged to `main`.