### PR TITLE
Add `install-uv` option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   python-version:
     description: 'The Python version to use. A value is required in order to install Python'
     required: false
+  install-uv:
+    description: 'If true, this installs uv'
+    required: false
+    default: false
   install-just:
     description: 'If true, this installs Just'
     required: false
@@ -27,6 +31,9 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: ${{ inputs.cache }}
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
+    - name: Install uv
+      if: ${{ inputs.install-uv == 'true' }}
+      uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6 # v6.6.1
     - name: Install just
       if: ${{ inputs.install-just == 'true' }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
         cache: ${{ inputs.cache }}
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
     - name: Install just
-      if: ${{ inputs.install-just }}
+      if: ${{ inputs.install-just == 'true' }}
       shell: bash
       run: |
         mkdir -p "$HOME/bin"


### PR DESCRIPTION
Similar to the `install-just` option, add an `install-uv` option to install `uv` using astral's `setup-uv` GitHub action. No default value is set here, but the repo-template will be setting this to `true`.

Using a commit sha following the docs on [Using third-party actions](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions).
Dependabot should be able to recognise that the sha corresponds to a specific version and propose updates.

`uv` is capable of installing `just`[^1][^2], but I haven't altered the `just` installation part of the action. We may wish to revisit how `just` is installed later, including using `uv` to install it if `install-uv` is set to `true`. We can also use `setup-just`. For flexibility in the future, I have placed the `uv` installation step before the `just` installation step.

Testing: 
- Verified that use of this branch with `install-uv` set to `true` allows running `uv` commands on CI. 
- Also verified that omitting the `install-uv` and trying to use a `uv` command would lead to failing CI as expected.

[^1]: [Slack discussion: uv can install just which can run uv](https://bennettoxford.slack.com/archives/C01T2HACV3K/p1727813025212819)
[^2]: [Slack discussion: Installing `just` with `uv tool install rust-just`](https://bennettoxford.slack.com/archives/C01T2HACV3K/p1742998727901259)