### PR TITLE
Enable caching for `uv`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,8 +29,8 @@ runs:
       if: ${{ inputs.python-version }}
       with:
         python-version: ${{ inputs.python-version }}
-        cache: ${{ inputs.cache }}
-        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+        cache: ${{ (inputs.cache == 'pip' || inputs.cache == 'pipenv' || inputs.cache == 'poetry') && inputs.cache || '' }}
+        cache-dependency-path: ${{ (inputs.cache == 'pip' || inputs.cache == 'pipenv' || inputs.cache == 'poetry') && inputs.cache-dependency-path || '' }}
     - name: Install uv
       if: ${{ inputs.install-uv == 'true' }}
       uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6 # v6.6.1

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Setup an OpenSAFELY environment'
 
 inputs:
   cache:
-    description: 'If dependencies should be cached, use this parameter to specify the package manager. Supported values: pip, pipenv, poetry. Set to null to disable dependency caching'
+    description: 'If dependencies should be cached, use this parameter to specify the package manager. Supported values: pip, pipenv, poetry, uv. Set to null to disable dependency caching'
     required: false
     default: 'pip'
   cache-dependency-path:
@@ -34,6 +34,8 @@ runs:
     - name: Install uv
       if: ${{ inputs.install-uv == 'true' }}
       uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6 # v6.6.1
+      with:
+        enable-cache: ${{ inputs.cache == 'uv' }}
     - name: Install just
       if: ${{ inputs.install-just == 'true' }}
       shell: bash


### PR DESCRIPTION
Requires https://github.com/opensafely-core/setup-action/pull/22 to be merged first as v6 of `setup-python` contains a bug fix that prevents itself from falling over when the cache directory is not used ("Change missing cache directory error to warning").

Enable caching for `uv` to speed up CI, and allow customisation of caching behaviour via the `cache` parameter as its possible values are already names of package managers. 

See the commit message for more.

Slack thread for breadcrumbs: https://bennettoxford.slack.com/archives/C091K4T1F9D/p1758112450986209